### PR TITLE
add command truncate support when building u-boot

### DIFF
--- a/recipes-bsp/u-boot/u-boot-rockpi.inc
+++ b/recipes-bsp/u-boot/u-boot-rockpi.inc
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/radxa/u-boot"
 LICENSE = "GPLv2+"
 COMPATIBLE_MACHINE = "(px30|rk3036|rk3066|rk3188|rk3288|rk3328|rk3399|rk3308|rk3399pro)"
 SECTION = "bootloaders"
-DEPENDS = "dtc-native bc-native swig-native bison-native"
+DEPENDS = "dtc-native bc-native swig-native bison-native coreutils-native"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Fix the issue of u-boot build error

    |   FDT:          fdt@1
    |   cp u-boot-dtb.bin u-boot.bin
    |   truncate -s "%8" u-boot.bin
    | /bin/sh: 1: truncate: not found

Signed-off-by: Stephen <stephen@vamrs.com>